### PR TITLE
Fixed NullRef exception calling BuyItem on editor

### DIFF
--- a/Soomla/Assets/Plugins/Soomla/Store/StoreEvents.cs
+++ b/Soomla/Assets/Plugins/Soomla/Store/StoreEvents.cs
@@ -329,9 +329,11 @@ namespace Soomla.Store {
 			}
 			if (eventJSON.HasField("extra")) {
 				var extraJSON = eventJSON["extra"];
-				foreach(string key in extraJSON.keys) {
-					if (extraJSON[key] != null) {
-						extra.Add(key, extraJSON[key].str);
+				if (extraJSON.keys != null) {
+					foreach(string key in extraJSON.keys) {
+						if (extraJSON[key] != null) {
+							extra.Add(key, extraJSON[key].str);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes Issue #409 (NullReferenceException when calling BuyItem from the editor) by surrounding the foreach with a null check
